### PR TITLE
Earizon code review new condition

### DIFF
--- a/src/main/java/org/interledger/Condition.java
+++ b/src/main/java/org/interledger/Condition.java
@@ -1,7 +1,13 @@
 package org.interledger;
 
+import java.net.URI;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.interledger.cryptoconditions.uri.URIEncodingException;
 
 /**
  * The execution condition attached to all transfers in an Interledger payment.
@@ -15,6 +21,9 @@ import java.util.Objects;
  * @see Fulfillment
  */
 public class Condition {
+
+  public static final String CONDITION_REGEX_STRICT = "^ni://([A-Za-z0-9_-]?)/sha-256;([a-zA-Z0-9_-]{0,86})\\?(.+)$";
+
 
   private final byte[] hash;
 
@@ -70,4 +79,30 @@ public class Condition {
     return Arrays.copyOf(this.hash, 32);
   }
 
+  /**
+   * Parses a URI formatted crypto-condition
+   *
+   * @param uri
+   *  The crypto-condition formatted as a uri.
+   * @return
+   *  The crypto condition
+   */
+  public static Condition parse(URI uri) throws URIEncodingException {
+    //based strongly on the five bells implementation at 
+    //https://github.com/interledgerjs/five-bells-condition (7b6a97990cd3a51ee41b276c290e4ae65feb7882)
+    
+    if (!"ni".equals(uri.getScheme())) {
+      throw new URIEncodingException("Serialized condition must start with 'ni:'");
+    }
+    
+    //the regex covers the entire uri format including the 'ni:' scheme
+    Matcher m = Pattern.compile(CONDITION_REGEX_STRICT).matcher(uri.toString());
+    
+    if (!m.matches()) {
+      throw new URIEncodingException("Invalid condition format");
+    }
+
+    byte[] fingerprint = Base64.getUrlDecoder().decode(m.group(2));
+    return new Condition(fingerprint);
+  }
 }

--- a/src/main/java/org/interledger/Condition.java
+++ b/src/main/java/org/interledger/Condition.java
@@ -7,7 +7,6 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.interledger.cryptoconditions.uri.URIEncodingException;
 
 /**
  * The execution condition attached to all transfers in an Interledger payment.
@@ -87,19 +86,19 @@ public class Condition {
    * @return
    *  The crypto condition
    */
-  public static Condition parse(URI uri) throws URIEncodingException {
+  public static Condition parse(URI uri) {
     //based strongly on the five bells implementation at 
     //https://github.com/interledgerjs/five-bells-condition (7b6a97990cd3a51ee41b276c290e4ae65feb7882)
     
     if (!"ni".equals(uri.getScheme())) {
-      throw new URIEncodingException("Serialized condition must start with 'ni:'");
+      throw new RuntimeException("Serialized condition must start with 'ni:'");
     }
     
     //the regex covers the entire uri format including the 'ni:' scheme
     Matcher m = Pattern.compile(CONDITION_REGEX_STRICT).matcher(uri.toString());
     
     if (!m.matches()) {
-      throw new URIEncodingException("Invalid condition format");
+      throw new RuntimeException("Invalid condition format");
     }
 
     byte[] fingerprint = Base64.getUrlDecoder().decode(m.group(2));

--- a/src/main/java/org/interledger/ilp/InterledgerError.java
+++ b/src/main/java/org/interledger/ilp/InterledgerError.java
@@ -14,7 +14,7 @@ public class InterledgerError {
   /**
    * Valid error codes that might be encountered during an Interledger payment.
    */
-  enum ErrorCode {
+  public enum ErrorCode {
     F00_BAD_REQUEST("F00", "BAD REQUEST"),
     F01_INVALID_PAQUET("F01", "INVALID PACKET"),
     F02_UNREACHABLE("F02", "UNREACHABLE"),

--- a/src/main/java/org/interledger/ledger/model/LedgerInfo.java
+++ b/src/main/java/org/interledger/ledger/model/LedgerInfo.java
@@ -9,7 +9,8 @@ import javax.money.format.MonetaryAmountFormat;
 
 public interface LedgerInfo {
 
-  // TODO Is this required?
+  // TODO Is this required? 
+  //      Answer: NO, getAddressPrefix is the real Id.
   String getId();
 
   /**

--- a/src/main/java/org/interledger/ledger/model/LedgerTransfer.java
+++ b/src/main/java/org/interledger/ledger/model/LedgerTransfer.java
@@ -1,6 +1,7 @@
 package org.interledger.ledger.model;
 
 import org.interledger.Condition;
+
 import org.interledger.InterledgerAddress;
 
 import java.time.ZonedDateTime;
@@ -34,7 +35,7 @@ public interface LedgerTransfer {
   MonetaryAmount getAmount();
 
   /**
-   * TODO:??.
+   * TODO:??. Doesn't look to be part of ILP protocol.
    */
   boolean isAuthorized();
 


### PR DESCRIPTION
I adapted the existing java-vertx-ledger code to the new changes and found some needed changes in java-ilp-core. This PR is the summary of the code review I realized.

NOTE: The static utility method Condition.parse(URI...) is needed by the ledger when receiving the condition through the REST API interfaces:
  - PUT /.../transfers/:transferUUID
    body { .... , "execution_condition": "ni:...." }
  - get /.../transfers/byExecutionCondition/..../
